### PR TITLE
Add expandable rows to portfolio table

### DIFF
--- a/client/src/components/PortfolioCard.tsx
+++ b/client/src/components/PortfolioCard.tsx
@@ -59,28 +59,20 @@ export function PortfolioCard() {
           <TableBody>
             {balances.data?.tokens.map((token) => {
               const isExpanded = expandedRows.has(token.id)
-              const hasMultipleAccounts =
-                token.accountBreakdown && token.accountBreakdown.length > 1
 
               return (
                 <>
                   <TableRow
                     key={token.id}
-                    className={hasMultipleAccounts ? 'cursor-pointer' : ''}
-                    onClick={
-                      hasMultipleAccounts
-                        ? () => toggleRow(token.id)
-                        : undefined
-                    }
+                    className="cursor-pointer"
+                    onClick={() => toggleRow(token.id)}
                   >
                     <TableCell>
-                      {hasMultipleAccounts && (
-                        <ChevronDownIcon
-                          className={`h-4 w-4 transition-transform ${
-                            isExpanded ? 'rotate-180' : ''
-                          }`}
-                        />
-                      )}
+                      <ChevronDownIcon
+                        className={`h-4 w-4 transition-transform ${
+                          isExpanded ? 'rotate-180' : ''
+                        }`}
+                      />
                     </TableCell>
                     <TableCell>{token.chain.name}</TableCell>
                     <TableCell title={token.symbol}>{token.name} </TableCell>

--- a/client/src/components/PortfolioCard.tsx
+++ b/client/src/components/PortfolioCard.tsx
@@ -1,4 +1,5 @@
-import { RefreshCcwIcon } from 'lucide-react'
+import { ChevronDownIcon, RefreshCcwIcon } from 'lucide-react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { useQueues } from '@/hooks/useQueues'
@@ -22,6 +23,19 @@ export function PortfolioCard() {
   const balances = useBalances()
   const { currency } = useCurrency()
   const { data: fiat } = useFiat()
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+
+  const toggleRow = (tokenId: number) => {
+    setExpandedRows((prev) => {
+      const newSet = new Set(prev)
+      if (newSet.has(tokenId)) {
+        newSet.delete(tokenId)
+      } else {
+        newSet.add(tokenId)
+      }
+      return newSet
+    })
+  }
 
   return (
     <Card>
@@ -34,6 +48,7 @@ export function PortfolioCard() {
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-12"></TableHead>
               <TableHead className="w-40 min-w-34">Chain</TableHead>
               <TableHead className="min-w-56">Token</TableHead>
               <TableHead className="w-44 min-w-40">Price</TableHead>
@@ -42,39 +57,109 @@ export function PortfolioCard() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {balances.data?.tokens.map((token) => (
-              <TableRow key={token.id}>
-                <TableCell>{token.chain.name}</TableCell>
-                <TableCell title={token.symbol}>{token.name} </TableCell>
-                <TableCell>
-                  {fiat &&
-                    formatCurrency(
-                      token.ethValuePerToken / fiat.getRate(currency),
-                      currency
-                    )}
-                </TableCell>
-                <TableCell>{toFixed(token.balance, 4)}</TableCell>
-                <TableCell
-                  className="text-right"
-                  title={`${toFixed(
-                    (token.ethValue / balances.data?.totalEthValue) * 100,
-                    2
-                  )}% of net value`}
-                >
-                  {!!token.ethValue &&
-                    fiat &&
-                    currency &&
-                    formatCurrency(
-                      token.ethValue / fiat.getRate(currency),
-                      currency
-                    )}
-                </TableCell>
-              </TableRow>
-            ))}
+            {balances.data?.tokens.map((token) => {
+              const isExpanded = expandedRows.has(token.id)
+              const hasMultipleAccounts =
+                token.accountBreakdown && token.accountBreakdown.length > 1
+
+              return (
+                <>
+                  <TableRow
+                    key={token.id}
+                    className={hasMultipleAccounts ? 'cursor-pointer' : ''}
+                    onClick={
+                      hasMultipleAccounts
+                        ? () => toggleRow(token.id)
+                        : undefined
+                    }
+                  >
+                    <TableCell>
+                      {hasMultipleAccounts && (
+                        <ChevronDownIcon
+                          className={`h-4 w-4 transition-transform ${
+                            isExpanded ? 'rotate-180' : ''
+                          }`}
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell>{token.chain.name}</TableCell>
+                    <TableCell title={token.symbol}>{token.name} </TableCell>
+                    <TableCell>
+                      {fiat &&
+                        formatCurrency(
+                          token.ethValuePerToken / fiat.getRate(currency),
+                          currency
+                        )}
+                    </TableCell>
+                    <TableCell>{toFixed(token.balance, 4)}</TableCell>
+                    <TableCell
+                      className="text-right"
+                      title={`${toFixed(
+                        (token.ethValue / balances.data?.totalEthValue) * 100,
+                        2
+                      )}% of net value`}
+                    >
+                      {!!token.ethValue &&
+                        fiat &&
+                        currency &&
+                        formatCurrency(
+                          token.ethValue / fiat.getRate(currency),
+                          currency
+                        )}
+                    </TableCell>
+                  </TableRow>
+                  {isExpanded && token.accountBreakdown && (
+                    <TableRow key={`${token.id}-breakdown`}>
+                      <TableCell colSpan={6} className="bg-muted/50 p-4">
+                        <div className="space-y-2">
+                          <div className="text-sm font-medium text-muted-foreground">
+                            Account Breakdown
+                          </div>
+                          <div className="space-y-1">
+                            {token.accountBreakdown.map((account) => (
+                              <div
+                                key={account.account.id}
+                                className="flex items-center justify-between text-sm"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium">
+                                    {account.account.name}
+                                  </span>
+                                  {account.account.address && (
+                                    <span className="text-xs text-muted-foreground">
+                                      {account.account.address.slice(0, 6)}...
+                                      {account.account.address.slice(-4)}
+                                    </span>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-4">
+                                  <span className="text-muted-foreground">
+                                    {toFixed(account.balance, 4)} (
+                                    {toFixed(account.percentage, 2)}%)
+                                  </span>
+                                  <span className="font-medium">
+                                    {fiat &&
+                                      currency &&
+                                      formatCurrency(
+                                        account.ethValue / fiat.getRate(currency),
+                                        currency
+                                      )}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </>
+              )
+            })}
           </TableBody>
           <TableFooter>
             <TableRow>
-              <TableCell colSpan={4}>Total</TableCell>
+              <TableCell colSpan={5}>Total</TableCell>
               <TableCell className="text-right">
                 {fiat &&
                   currency &&

--- a/client/src/components/PortfolioCard.tsx
+++ b/client/src/components/PortfolioCard.tsx
@@ -111,30 +111,23 @@ export function PortfolioCard() {
                   {isExpanded && token.accountBreakdown && (
                     <TableRow key={`${token.id}-breakdown`}>
                       <TableCell colSpan={6} className="p-0">
-                        <div className="divide-y divide-border">
+                        <div className="divide-border divide-y">
                           {token.accountBreakdown.map((account, idx) => (
                             <div
                               key={account.account.id}
-                              className={`flex items-center justify-between px-4 py-3 text-sm ${
-                                idx % 2 === 0 ? 'bg-muted/30' : 'bg-muted/50'
+                              className={`flex items-center justify-between p-2 text-sm ${
+                                idx % 2 === 0 ? 'bg-muted/20' : 'bg-muted'
                               }`}
                             >
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium">
-                                  {account.account.name}
-                                </span>
-                                {account.account.address && (
-                                  <span className="text-xs text-muted-foreground">
-                                    {account.account.address.slice(0, 6)}...
-                                    {account.account.address.slice(-4)}
-                                  </span>
-                                )}
-                              </div>
-                              <div className="flex items-center gap-6">
+                              <span className="font-medium">
+                                {account.account.name}
+                              </span>
+                              <div className="flex items-center gap-4">
                                 <span className="text-muted-foreground tabular-nums">
-                                  {toFixed(account.balance, 4)} ({toFixed(account.percentage, 2)}%)
+                                  {toFixed(account.balance, 3)} (
+                                  {toFixed(account.percentage, 2)}%)
                                 </span>
-                                <span className="font-medium tabular-nums min-w-[100px] text-right">
+                                <span className="min-w-28 text-right font-medium tabular-nums">
                                   {fiat &&
                                     currency &&
                                     formatCurrency(

--- a/client/src/components/PortfolioCard.tsx
+++ b/client/src/components/PortfolioCard.tsx
@@ -110,45 +110,41 @@ export function PortfolioCard() {
                   </TableRow>
                   {isExpanded && token.accountBreakdown && (
                     <TableRow key={`${token.id}-breakdown`}>
-                      <TableCell colSpan={6} className="bg-muted/50 p-4">
-                        <div className="space-y-2">
-                          <div className="text-sm font-medium text-muted-foreground">
-                            Account Breakdown
-                          </div>
-                          <div className="space-y-1">
-                            {token.accountBreakdown.map((account) => (
-                              <div
-                                key={account.account.id}
-                                className="flex items-center justify-between text-sm"
-                              >
-                                <div className="flex items-center gap-2">
-                                  <span className="font-medium">
-                                    {account.account.name}
+                      <TableCell colSpan={6} className="p-0">
+                        <div className="divide-y divide-border">
+                          {token.accountBreakdown.map((account, idx) => (
+                            <div
+                              key={account.account.id}
+                              className={`flex items-center justify-between px-4 py-3 text-sm ${
+                                idx % 2 === 0 ? 'bg-muted/30' : 'bg-muted/50'
+                              }`}
+                            >
+                              <div className="flex items-center gap-2">
+                                <span className="font-medium">
+                                  {account.account.name}
+                                </span>
+                                {account.account.address && (
+                                  <span className="text-xs text-muted-foreground">
+                                    {account.account.address.slice(0, 6)}...
+                                    {account.account.address.slice(-4)}
                                   </span>
-                                  {account.account.address && (
-                                    <span className="text-xs text-muted-foreground">
-                                      {account.account.address.slice(0, 6)}...
-                                      {account.account.address.slice(-4)}
-                                    </span>
-                                  )}
-                                </div>
-                                <div className="flex items-center gap-4">
-                                  <span className="text-muted-foreground">
-                                    {toFixed(account.balance, 4)} (
-                                    {toFixed(account.percentage, 2)}%)
-                                  </span>
-                                  <span className="font-medium">
-                                    {fiat &&
-                                      currency &&
-                                      formatCurrency(
-                                        account.ethValue / fiat.getRate(currency),
-                                        currency
-                                      )}
-                                  </span>
-                                </div>
+                                )}
                               </div>
-                            ))}
-                          </div>
+                              <div className="flex items-center gap-6">
+                                <span className="text-muted-foreground tabular-nums">
+                                  {toFixed(account.balance, 4)} ({toFixed(account.percentage, 2)}%)
+                                </span>
+                                <span className="font-medium tabular-nums min-w-[100px] text-right">
+                                  {fiat &&
+                                    currency &&
+                                    formatCurrency(
+                                      account.ethValue / fiat.getRate(currency),
+                                      currency
+                                    )}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
                         </div>
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
This commit implements expandable rows in the portfolio table to show which accounts own each asset and their respective percentages.

Backend changes:
- Modified getBalances handler to include account breakdown data
- Added accountBreakdown array with account details, balance, and percentage
- Sorted accounts by balance (highest first)

Frontend changes:
- Added expandable row functionality with chevron icon
- Only rows with multiple accounts are expandable
- Clicking row toggles account breakdown display
- Shows account name, address (truncated), balance, percentage, and value
- Added smooth rotation animation for chevron icon